### PR TITLE
Add movie details and videos

### DIFF
--- a/db/v2/migrations/20200618170850_add_movie_details.js
+++ b/db/v2/migrations/20200618170850_add_movie_details.js
@@ -1,0 +1,18 @@
+
+exports.up = function(knex) {
+  return knex.schema.table('movies', function(table){
+    table.integer('budget').unsigned();
+    table.integer('revenue').unsigned();
+    table.integer('runtime').unsigned();
+    table.string('tagline');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('movies', function(table){
+    table.dropColumn('budget');
+    table.dropColumn('revenue');
+    table.dropColumn('runtime');
+    table.dropColumn('tagline');
+  });
+};

--- a/db/v2/migrations/20200619071629_movies_videos.js
+++ b/db/v2/migrations/20200619071629_movies_videos.js
@@ -1,0 +1,13 @@
+
+exports.up = function(knex, Promise) {
+  return knex.schema.createTable('movies_videos', function(table){
+      table.increments('id').primary();
+      table.integer('movie_id').unsigned().references('movies.id');
+      table.string('key');
+      table.string('site');
+      table.string('type');
+    })
+};
+exports.down = function(knex, Promise) {
+  return knex.schema.dropTable('movies_videos')
+};

--- a/db/v2/seeds/dev/2-movies.js
+++ b/db/v2/seeds/dev/2-movies.js
@@ -8,37 +8,28 @@ const fetchIndividualMovieDetails = movies => {
     return fetch(`https://api.themoviedb.org/3/movie/${movie.id}?api_key=${process.env.MOVIE_DB_APIKEY}&language=en-US`)
       .then(response => response.json())
       .then(movieDetails => {
-        const { budget, revenue, runtime, tagline } = movieDetails;
-        return {...movie, budget, revenue, runtime, tagline };
-      })
+        return { ...movie, ...movieDetails };
+      });
   });
 
   return Promise.all(moviePromises);
 }
 
-const fetchMoviesAndSupportingData = () => {
+const fetchMovies = () => {
   const pages = [1, 2];
   // flattened array of movies
-  const moviesPromise = Promise.all(pages.map(pageNum => {
+  return Promise.all(pages.map(pageNum => {
     return fetch(`https://api.themoviedb.org/3/movie/now_playing?api_key=${process.env.MOVIE_DB_APIKEY}&language=en-US&page=${pageNum}`)
       .then(response => response.json())
       .then(movieData => movieData.results)
   }))
   .then(moviePages => [].concat.apply([], moviePages))
   .then(movies => fetchIndividualMovieDetails(movies));
-
-  // array of genres and associated ids
-  const genresPromise = fetch(`https://api.themoviedb.org/3/genre/movie/list?api_key=${process.env.MOVIE_DB_APIKEY}&language=en-US`)
-    .then(response => response.json())
-    .then(genreData => genreData.genres);
-
-  return Promise.all([moviesPromise, genresPromise]);
 };
 
-const replaceGenreIdsWithGenreName = (movieGenreIds, genreIdsAndNames) => {
-  return movieGenreIds.map(movieGenreId => {
-    const matchingGenre = genreIdsAndNames.find(genreIdAndName => genreIdAndName.id === movieGenreId);
-    return matchingGenre.name;
+const cleanGenres = genreIdsAndNames => {
+  return genreIdsAndNames.map(genreIdAndName => {
+    return genreIdAndName.name;
   });
 };
 
@@ -53,13 +44,12 @@ const formatImageURLs = movie => {
   return { full_poster_path, full_backdrop_path }
 };
 
-const buildMovieData = moviesAndSupportingData => {
-  const [movies, genreIdsAndNames] = moviesAndSupportingData;
+const buildMovieData = movies => {
 
   return movies.map(movie => {
-    const { id, title, overview, release_date, genre_ids, budget, revenue, runtime, tagline } = movie;
+    const { id, title, overview, release_date, genres, budget, revenue, runtime, tagline } = movie;
 
-    const genres = replaceGenreIdsWithGenreName(genre_ids, genreIdsAndNames);
+    const cleanedGenres = cleanGenres(genres);
     const { full_poster_path, full_backdrop_path } = formatImageURLs(movie);
 
     return {
@@ -69,7 +59,7 @@ const buildMovieData = moviesAndSupportingData => {
       title,
       overview,
       release_date,
-      genres: JSON.stringify(genres),
+      genres: JSON.stringify(cleanedGenres),
       budget,
       revenue,
       runtime,
@@ -79,8 +69,8 @@ const buildMovieData = moviesAndSupportingData => {
 };
 
 exports.seed = (knex) => {
-  return fetchMoviesAndSupportingData()
-    .then(moviesAndSupportingData => buildMovieData(moviesAndSupportingData))
+  return fetchMovies()
+    .then(movies => buildMovieData(movies))
     .then(cleanedMovies => {
       return knex('movies').insert(cleanedMovies);
     })

--- a/db/v2/seeds/dev/2-movies.js
+++ b/db/v2/seeds/dev/2-movies.js
@@ -1,24 +1,38 @@
 
-// Movies from https://developers.themoviedb.org/3/movies/get-now-playing (1st page)
+// Movies from https://developers.themoviedb.org/3/movies/get-now-playing (it is paginated)
 const fetch = require('node-fetch');
 require('dotenv').config();
+
+const fetchIndividualMovieDetails = movies => {
+  const moviePromises = movies.map(movie => {
+    return fetch(`https://api.themoviedb.org/3/movie/${movie.id}?api_key=${process.env.MOVIE_DB_APIKEY}&language=en-US`)
+      .then(response => response.json())
+      .then(movieDetails => {
+        const { budget, revenue, runtime, tagline } = movieDetails;
+        return {...movie, budget, revenue, runtime, tagline };
+      })
+  });
+
+  return Promise.all(moviePromises);
+}
 
 const fetchMoviesAndSupportingData = () => {
   const pages = [1, 2];
   // flattened array of movies
-  const moviePagesPromise = Promise.all(pages.map(pageNum => {
+  const moviesPromise = Promise.all(pages.map(pageNum => {
     return fetch(`https://api.themoviedb.org/3/movie/now_playing?api_key=${process.env.MOVIE_DB_APIKEY}&language=en-US&page=${pageNum}`)
       .then(response => response.json())
       .then(movieData => movieData.results)
   }))
-  .then(moviePages => [].concat.apply([], moviePages));
+  .then(moviePages => [].concat.apply([], moviePages))
+  .then(movies => fetchIndividualMovieDetails(movies));
 
   // array of genres and associated ids
   const genresPromise = fetch(`https://api.themoviedb.org/3/genre/movie/list?api_key=${process.env.MOVIE_DB_APIKEY}&language=en-US`)
     .then(response => response.json())
     .then(genreData => genreData.genres);
 
-  return Promise.all([moviePagesPromise, genresPromise]);
+  return Promise.all([moviesPromise, genresPromise]);
 };
 
 const replaceGenreIdsWithGenreName = (movieGenreIds, genreIdsAndNames) => {
@@ -43,7 +57,7 @@ const buildMovieData = moviesAndSupportingData => {
   const [movies, genreIdsAndNames] = moviesAndSupportingData;
 
   return movies.map(movie => {
-    const { id, title, overview, release_date, genre_ids } = movie;
+    const { id, title, overview, release_date, genre_ids, budget, revenue, runtime, tagline } = movie;
 
     const genres = replaceGenreIdsWithGenreName(genre_ids, genreIdsAndNames);
     const { full_poster_path, full_backdrop_path } = formatImageURLs(movie);
@@ -55,7 +69,11 @@ const buildMovieData = moviesAndSupportingData => {
       title,
       overview,
       release_date,
-      genres: JSON.stringify(genres)
+      genres: JSON.stringify(genres),
+      budget,
+      revenue,
+      runtime,
+      tagline
     };
   });
 };

--- a/db/v2/seeds/dev/2-movies.js
+++ b/db/v2/seeds/dev/2-movies.js
@@ -27,7 +27,7 @@ const fetchMovies = () => {
   .then(movies => fetchIndividualMovieDetails(movies));
 };
 
-const cleanGenres = genreIdsAndNames => {
+const extractNamesFromGenresList = genreIdsAndNames => {
   return genreIdsAndNames.map(genreIdAndName => {
     return genreIdAndName.name;
   });
@@ -49,7 +49,7 @@ const buildMovieData = movies => {
   return movies.map(movie => {
     const { id, title, overview, release_date, genres, budget, revenue, runtime, tagline } = movie;
 
-    const cleanedGenres = cleanGenres(genres);
+    const cleanedGenres = extractNamesFromGenresList(genres);
     const { full_poster_path, full_backdrop_path } = formatImageURLs(movie);
 
     return {

--- a/db/v2/seeds/dev/2-movies.js
+++ b/db/v2/seeds/dev/2-movies.js
@@ -68,11 +68,54 @@ const buildMovieData = movies => {
   });
 };
 
+const insertVideos = (knex, videoData) => {
+  // videData is an array of arrays
+  return Promise.all(videoData.map(videoSet => {
+    if (videoSet) {
+      return Promise.all(videoSet.map(video => {
+        return knex('movies_videos').insert({
+          movie_id: video.id,
+          key: video.key,
+          site: video.site,
+          type: video.type
+        });
+      }));
+    }
+  }));
+};
+
+const fetchVideos = movies => {
+  return Promise.all(movies.map(movie => {
+    return fetch(`https://api.themoviedb.org/3/movie/${movie.id}/videos?api_key=${process.env.MOVIE_DB_APIKEY}&language=en-US`)
+      .then(response => response.json())
+      .then(videoData => {
+        if (videoData.results.length) {
+          return videoData.results.map(result => {
+            const { key, site, type } = result;
+            return { id: movie.id, key, site, type };
+          });
+        } else {
+          return null;
+        }
+      });
+  }));
+};
+
+const addVideosForMovies = knex => {
+  return knex('movies').select('id').then(movieIDs => {
+    return fetchVideos(movieIDs)
+      .then(videoData => insertVideos(knex, videoData));
+  });
+};
+
 exports.seed = (knex) => {
   return fetchMovies()
     .then(movies => buildMovieData(movies))
     .then(cleanedMovies => {
       return knex('movies').insert(cleanedMovies);
+    })
+    .then(() => {
+      return addVideosForMovies(knex);
     })
     .catch(err => console.log('Error seeding movies:', err));
 };

--- a/routes/router-v2.js
+++ b/routes/router-v2.js
@@ -128,6 +128,17 @@ routerV2.get('/movies/:movie_id', checkIfMovieExists('params'), (request, respon
     .catch(error => response.status(500).json({ error }));
 });
 
+// GET videos for a particular movie
+routerV2.get('/movies/:movie_id/videos', checkIfMovieExists('params'), (request, response) => {
+  const { movie_id } = request.params;
+
+  databaseV2('movies_videos').where({movie_id: movie_id})
+    .then(videos => {
+      return response.status(200).json({ videos });
+    })
+    .catch(error => response.status(500).json({ error }));
+});
+
 // GET all ratings for a user
 routerV2.get('/users/:user_id/ratings', checkIfUserExistsFromParam, (request, response) => {
   const { user_id } = request.params;

--- a/routes/router-v2.js
+++ b/routes/router-v2.js
@@ -95,7 +95,21 @@ routerV2.get('/movies', (request, response) => {
       Promise.all(movies.map(movie => {
         return calculateAverageRatingForMovie(movie);
       }))
-      .then(movies => response.status(200).json({ movies }))
+      .then(movies => {
+        const strippedDetailsMovies = movies.map(movie => {
+          const {id, poster_path, backdrop_path, title, average_rating, release_date} = movie;
+
+          return {
+            id,
+            poster_path,
+            backdrop_path,
+            title,
+            average_rating,
+            release_date
+          }
+        });
+        return response.status(200).json({ movies: strippedDetailsMovies })
+      })
     })
     .catch(error => response.status(500).json({ error }));
 });

--- a/test/server-v1.test.js
+++ b/test/server-v1.test.js
@@ -5,6 +5,8 @@ const request = require('supertest');
 beforeEach(async () => {
   // Reset seed db with primary keys reset
   await databaseV1.migrate.rollback();
+  await databaseV1.migrate.rollback();
+  await databaseV1.migrate.rollback();
   await databaseV1.migrate.latest();
   await databaseV1.seed.run();
 })

--- a/test/server-v1.test.js
+++ b/test/server-v1.test.js
@@ -5,8 +5,6 @@ const request = require('supertest');
 beforeEach(async () => {
   // Reset seed db with primary keys reset
   await databaseV1.migrate.rollback();
-  await databaseV1.migrate.rollback();
-  await databaseV1.migrate.rollback();
   await databaseV1.migrate.latest();
   await databaseV1.seed.run();
 })

--- a/test/server-v2.test.js
+++ b/test/server-v2.test.js
@@ -5,6 +5,8 @@ const request = require('supertest');
 beforeEach(async () => {
   // Reset seed db with primary keys reset
   await databaseV2.migrate.rollback();
+  await databaseV2.migrate.rollback();
+  await databaseV2.migrate.rollback();
   await databaseV2.migrate.latest();
   await databaseV2.seed.run();
 })

--- a/test/server-v2.test.js
+++ b/test/server-v2.test.js
@@ -4,9 +4,7 @@ const request = require('supertest');
 
 beforeEach(async () => {
   // Reset seed db with primary keys reset
-  await databaseV2.migrate.rollback();
-  await databaseV2.migrate.rollback();
-  await databaseV2.migrate.rollback();
+  await databaseV2.migrate.rollback(null, true); // "true" refers to rollback all migrations
   await databaseV2.migrate.latest();
   await databaseV2.seed.run();
 })


### PR DESCRIPTION
# Overview
This PR adds movie details to the existing movies as well as movie videos for API v2. It also adjusts the API v2 test because of the additional migrations.

## Movie Details
The details added are:
* budget
* revenue
* runtime
* tagline

The route `/api/v2/movies` gives all movies without details:
* id
* poster_path
* backdrop_path
* title
* average_rating
* release_date

The details are visible only at the route for each movie, `/api/v2/movies/:movie_id`, which shows:
* id
* title
* poster_path
* backdrop_path
* release_date
* overview
* genres
* budget
* revenue
* runtime
* tagline
* average_rating

One thing about the movie details that were added is that sometimes there is no data available. For instance, "revenue" might be "0" if there is nothing reported. I think this can be good for students, though, to see a little sparseness in the data.

## Movie Videos
The movie videos are held in a table called `movies_videos` with a one-to-many relationship - the `movie_id` is the foreign key that connects to the movie.

The endpoint these are available at is `/api/v2/movies/:movie_id/videos`, and it returns an array of movies related to a specific movie.

Some movies do not have videos, so the endpoint should give back an empty array if no videos are found with a movie's id.

## Testing

~~Since there are additional migrations added, the tests need to make sure that for each test the database is totally reset. Unfortunately, knex does not have a function that will guarantee to rollback _all_ migrations. So you have to put as many rollbacks as there are migration files to guarantee that the DB is completely rolled back before running the latest migration set.~~

~~So that is why there are repetitive lines of `await databaseV1.migrate.rollback();` in the API v2 test file.~~

[This feature](https://github.com/knex/documentation/pull/170) was actually added since I last used knex extensively, which enables an optional argument to rollback all migrations, which is awesome. This has been added into the v2 test file.

## Documentation

One thing I didn't do is update the endpoint documentation in the project spec (both for the addition of the videos and the change in what is served for movies and movie details).